### PR TITLE
implement kernel_info_request

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@
 # Please keep the list sorted.
 
 Nicolas Riesco <enquiries@nicolasriesco.net>
+Min RK <benjaminrk@gmail.com>

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -44,6 +44,12 @@ var zmq = require("zmq");
 
 var DEBUG = false;
 
+var protocol_version = [4, 1];
+// node_version can be left as str in protocol v5
+var node_version = process.versions.node.split('.').map(function (v) {
+    return parseInt(v, 10);
+});
+
 /**
  * Class to implement a javascript kernel for an ipython notebook.
  *
@@ -76,6 +82,7 @@ function Kernel(ipythonConfig, vmConfig) {
             prototype[msg_type].call(this, msg);
         } else {
             // Ignore unimplemented msg_type requests
+            console.warn("Unhandled message type:", msg_type);
         }
     }
 
@@ -91,6 +98,22 @@ function Kernel(ipythonConfig, vmConfig) {
         this.hbSocket.send(message);
     });
 }
+
+
+/**
+ * Kernel info request.
+ *
+ * @param {Message} request - request message
+ */
+Kernel.prototype.kernel_info_request = function(request) {
+    request.respond(
+        this.shellSocket,
+        "kernel_info_reply", {
+            "language": "javascript",
+            "language_version": node_version,
+            "protocol_version": protocol_version,
+        });
+};
 
 /**
  * Execute request.

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -44,9 +44,9 @@ var zmq = require("zmq");
 
 var DEBUG = false;
 
-var protocol_version = [4, 1];
+var protocolVersion = [4, 1];
 // node_version can be left as str in protocol v5
-var node_version = process.versions.node.split('.').map(function (v) {
+var nodeVersion = process.versions.node.split('.').map(function (v) {
     return parseInt(v, 10);
 });
 
@@ -110,8 +110,8 @@ Kernel.prototype.kernel_info_request = function(request) {
         this.shellSocket,
         "kernel_info_reply", {
             "language": "javascript",
-            "language_version": node_version,
-            "protocol_version": protocol_version,
+            "language_version": nodeVersion,
+            "protocol_version": protocolVersion,
         });
 };
 


### PR DESCRIPTION
replying to kernel_info requests is necessary to work with IPython ≥ 3