### PR TITLE
send busy/idle status messages

### DIFF
--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -123,7 +123,13 @@ function Kernel(ipythonConfig) {
 
         var msg_type = msg.header.msg_type;
         if (this.handlers.hasOwnProperty(msg_type)) {
+            msg.respond(this.iopubSocket, 'status', {
+                execution_state: 'busy'
+            });
             this.handlers[msg_type].call(this, msg);
+            msg.respond(this.iopubSocket, 'status', {
+                execution_state: 'idle'
+            });
         } else {
             // Ignore unimplemented msg_type requests
             console.warn("KERNEL: SHELL_SOCKET: Unhandled message type:", msg_type);


### PR DESCRIPTION
These tell the frontend(s) when processing a request has started/completed