### PR TITLE
fix some wire protocol implementation details

### DIFF
--- a/lib/jp.js
+++ b/lib/jp.js
@@ -69,6 +69,7 @@
 module.exports.Message = Message;
 
 var DEBUG = false;
+var DELIMITER = '<IDS|MSG>';
 
 var console = require("console");
 var crypto = require("crypto");
@@ -85,13 +86,12 @@ var uuid = require("node-uuid");
  */
 function Message(requestArguments, scheme, key) {
     this.idents = undefined;
-    this.delimiter = undefined;
     this.signature = undefined;
     this.header = undefined;
     this.parentHeader = undefined;
     this.metadata = undefined;
     this.content = undefined;
-    this.blob = undefined;
+    this.blobs = undefined;
 
     this.scheme = scheme || "sha256";
     this.key = key || "";
@@ -109,38 +109,48 @@ function Message(requestArguments, scheme, key) {
  * the {@link Kernel#shellSocket Shell socket}
  */
 Message.prototype.parse = function(requestArguments) {
-    var hmac = crypto.createHmac(this.scheme, this.key);
-    hmac.update(requestArguments[3]);
-    hmac.update(requestArguments[4]);
-    hmac.update(requestArguments[5]);
-    hmac.update(requestArguments[6]);
-    this.signature = requestArguments[2].toString();
-    this.signatureOK = (this.signature === hmac.digest("hex"));
+    var i = 0;
+    this.idents = [];
+    for (i = 0; i < requestArguments.length; i++) {
+        var part = requestArguments[i];
+        if (part.toString() === DELIMITER) {
+            break;
+        }
+        this.idents.push(part);
+    }
+    if (requestArguments.length - i < 5) {
+        console.warn("Not enough msg parts", requestArguments);
+        return;
+    }
+    if (requestArguments[i].toString() !== DELIMITER) {
+        console.warn("Invalid msg", requestArguments);
+        return;
+    }
+    
+    if (this.key === '') {
+        // no key, messages aren't signed
+        this.signatureOK = (this.signature === '');
+    } else {
+        this.signature = requestArguments[i+1].toString();
+        var hmac = crypto.createHmac(this.scheme, this.key);
+        hmac.update(requestArguments[i+2]);
+        hmac.update(requestArguments[i+3]);
+        hmac.update(requestArguments[i+4]);
+        hmac.update(requestArguments[i+5]);
+        this.signatureOK = (this.signature === hmac.digest("hex"));
+    }
 
     if (!this.signatureOK) return;
 
-    function toString(value) {
-        if (value === undefined || value === null) {
-            return value;
-        }
-        return value.toString();
-    }
-
     function toJSON(value) {
-        if (value === undefined || value === null) {
-            return value;
-        }
         return JSON.parse(value.toString());
     }
-
-    this.idents = toString(requestArguments[0]);
-    this.delimiter = toString(requestArguments[1]);
-
-    this.header = toJSON(requestArguments[3]);
-    this.parentHeader = toJSON(requestArguments[4]);
-    this.metadata = toString(requestArguments[5]);
-    this.content = toJSON(requestArguments[6]);
-    this.blob = toString(requestArguments[7]);
+    
+    this.header = toJSON(requestArguments[i+2]);
+    this.parentHeader = toJSON(requestArguments[i+3]);
+    this.metadata = toJSON(requestArguments[i+4]);
+    this.content = toJSON(requestArguments[i+5]);
+    this.blobs = Array.prototype.slice.apply(requestArguments, [i+6]);
 
     if (DEBUG) console.log("JP: REQUEST:", this);
 };
@@ -154,7 +164,6 @@ Message.prototype.parse = function(requestArguments) {
  */
 Message.prototype.respond = function(socket, messageType, content) {
     var idents = this.idents;
-    var delimiter = this.delimiter;
     var header = JSON.stringify({
         msg_id: uuid.v4(),
         username: this.header.username,
@@ -164,17 +173,18 @@ Message.prototype.respond = function(socket, messageType, content) {
     var parentHeader = JSON.stringify(this.header);
     var metadata = JSON.stringify({});
     content = JSON.stringify(content);
-
-    var hmac = crypto.createHmac(this.scheme, this.key);
-    hmac.update(header);
-    hmac.update(parentHeader);
-    hmac.update(metadata);
-    hmac.update(content);
-    var signature = hmac.digest("hex");
-
-    if (DEBUG) console.log("JP: RESPONSE:", [
-        idents, // idents
-        delimiter, // delimiter
+    var signature = '';
+    if (this.key !== '') {
+        var hmac = crypto.createHmac(this.scheme, this.key);
+        hmac.update(header);
+        hmac.update(parentHeader);
+        hmac.update(metadata);
+        hmac.update(content);
+        signature = hmac.digest("hex");
+    }
+    
+    var response = idents.concat([ // idents
+        DELIMITER, // delimiter
         signature, // HMAC signature
         header, // header
         parentHeader, // parent header
@@ -182,13 +192,7 @@ Message.prototype.respond = function(socket, messageType, content) {
         content, // content
     ]);
 
-    socket.send([
-        idents, // idents
-        delimiter, // delimiter
-        signature, // HMAC signature
-        header, // header
-        parentHeader, // parent header
-        metadata, // metadata
-        content, // content
-    ]);
+    if (DEBUG) console.log("JP: RESPONSE:", response);
+
+    socket.send(response);
 };

--- a/lib/jp.js
+++ b/lib/jp.js
@@ -98,7 +98,11 @@ function Message(requestArguments, scheme, key) {
     this.signatureOK = undefined;
 
     if (requestArguments !== undefined) {
-        this.parse(requestArguments);
+        try {
+            this.parse(requestArguments);
+        } catch (e) {
+            console.error("Failed to parse msg", requestArguments, e.stack);
+        }
     }
 }
 


### PR DESCRIPTION
- there can be 0-many idents
- leave idents as buffers because they are arbitrary bytes, not necessarily strings
- empty key means no signatures

It was casting idents to strings that was causing #5, because the kernel_info_reply was not sent to the correct destination.

closes #5