### PR TITLE
incremental stdout/stderr forwarding

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,5 +6,6 @@
 
 # Please keep the list sorted.
 
+Kevin Kwok <kkwok@mit.edu>
 Min RK <benjaminrk@gmail.com>
 Nicolas Riesco <enquiries@nicolasriesco.net>

--- a/lib/handlers_v4.js
+++ b/lib/handlers_v4.js
@@ -99,25 +99,26 @@ function execute_request(request) {
     }
 
     function afterRun(session) {
-        if (session.result.stdout) {
-            request.respond(
-                this.iopubSocket,
-                "stream", {
-                    name: "stdout",
-                    data: session.result.stdout,
-                }
-            );
-        }
+    }
 
-        if (session.result.stderr) {
-            request.respond(
-                this.iopubSocket,
-                "stream", {
-                    name: "stderr",
-                    data: session.result.stderr,
-                }
-            );
-        }
+    function onStdout(data){
+        request.respond(
+            this.iopubSocket,
+            "stream", {
+                name: "stdout",
+                data: data,
+            }
+        );
+    }
+    
+    function onStderr(data){
+        request.respond(
+            this.iopubSocket,
+            "stream", {
+                name: "stderr",
+                data: data,
+            }
+        );
     }
 
     function onSuccess(session) {
@@ -168,6 +169,8 @@ function execute_request(request) {
         code: request.content.code,
         beforeRun: beforeRun.bind(this),
         afterRun: afterRun.bind(this),
+        onStdout: onStdout.bind(this),
+        onStderr: onStderr.bind(this),
         onSuccess: onSuccess.bind(this),
         onError: onError.bind(this)
     };

--- a/lib/sm.js
+++ b/lib/sm.js
@@ -229,6 +229,13 @@ function Session(smConfig) {
     this._task = null;
 
     /**
+     * Task most recently run (`null` if none)
+     * @member {?module:sm~Task}
+     * @private
+     */
+    this._lastTask = null;
+
+    /**
      * Queue of tasks to be run
      * @member {module:sm~Task[]}
      * @private
@@ -258,6 +265,8 @@ function Session(smConfig) {
     this._killed = false;
 
     this._server.on("message", Session.prototype._onMessage.bind(this));
+    this._server.stdout.on("data", Session.prototype._onStdout.bind(this));
+    this._server.stderr.on("data", Session.prototype._onStderr.bind(this));
 }
 
 /**
@@ -311,8 +320,6 @@ Session._args = ["--eval", fs.readFileSync(paths.server)]; // --eval workaround
  *
  * @typedef Result
  *
- * @property {?string}  stdout            Stdout output
- * @property {?string}  stderr            Stderr output
  * @property            [mime]            Defined only for successful "run"
  *                                        actions
  * @property {string}   mime."text/plain" Result in plain text
@@ -330,6 +337,26 @@ Session._args = ["--eval", fs.readFileSync(paths.server)]; // --eval workaround
  */
 
 /**
+ * Callback to forward stdout from the session server
+ *
+ * @param data Stdout output
+ * @private
+ */
+Session.prototype._onStdout = function(data) {
+    this._lastTask.onStdout(data === null ? null : data.toString())
+};
+
+/**
+ * Callback to forward stderr from the session server
+ *
+ * @param data Stderr output
+ * @private
+ */
+Session.prototype._onStderr = function(data) {
+    this._lastTask.onStderr(data === null ? null : data.toString())
+};
+
+/**
  * Callback to handle messages from the session server
  *
  * @param {module:sm~Result} message Result of last execution request
@@ -338,12 +365,7 @@ Session._args = ["--eval", fs.readFileSync(paths.server)]; // --eval workaround
 Session.prototype._onMessage = function(message) {
     if (DEBUG) console.log("SM: MESSAGE", message);
 
-    var stdout = this._server.stdout.read();
-    var stderr = this._server.stderr.read();
-
     this.result = message;
-    this.result.stdout = (stdout === null) ? null : stdout.toString();
-    this.result.stderr = (stderr === null) ? null : stderr.toString();
 
     if (message.hasOwnProperty("error")) {
         this._task.onError(this);
@@ -388,6 +410,7 @@ Session.prototype.run = function(task) {
  */
 Session.prototype._runNow = function(task) {
     this._task = task;
+    this._lastTask = task;
     if (this._task.beforeRun) {
         this._task.beforeRun(this);
     }

--- a/lib/sm.js
+++ b/lib/sm.js
@@ -343,7 +343,9 @@ Session._args = ["--eval", fs.readFileSync(paths.server)]; // --eval workaround
  * @private
  */
 Session.prototype._onStdout = function(data) {
-    this._lastTask.onStdout(data === null ? null : data.toString())
+    if (this._lastTask) {
+        this._lastTask.onStdout(data === null ? null : data.toString());
+    }
 };
 
 /**
@@ -353,9 +355,10 @@ Session.prototype._onStdout = function(data) {
  * @private
  */
 Session.prototype._onStderr = function(data) {
-    this._lastTask.onStderr(data === null ? null : data.toString())
+    if (this._lastTask) {
+        this._lastTask.onStderr(data === null ? null : data.toString());
+    }
 };
-
 /**
  * Callback to handle messages from the session server
  *


### PR DESCRIPTION
This is useful for asynchronous or long-running scripts. Rather than waiting until a script is finished executing, it immediately forwards any stdout or stderr output to Jupyter under the latest task (even after a task has been completed). 