### PR TITLE
Use docstrap for documentation layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.swp
 misc/
 node_modules/
+npm-debug.log
 .ipynb_checkpoints/
 doc/output/
 doc/tutorials/*.html

--- a/doc/ipython.tpl
+++ b/doc/ipython.tpl
@@ -1,0 +1,75 @@
+<!--  Modified from full.tpl to remove twitter bootstrap -->
+{%- extends 'basic.tpl' -%}
+{% from 'mathjax.tpl' import mathjax %}
+
+
+{%- block header -%}
+<!DOCTYPE html>
+<html>
+<head>
+
+<meta charset="utf-8" />
+<title>{{resources['metadata']['name']}}</title>
+<!--
+<script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
+-->
+
+<!-- Get own version of resources.inlining.css -->
+<style type="text/css">
+/* IPython notebook */
+{{ resources.inlining.css[0].split('\n')[-5] }}
+/* IPython notebook webapp*/
+{{ resources.inlining.css[0].split('\n')[-1] }}
+{{ resources.inlining.css[1] }}
+</style>
+<style type="text/css">
+/* Overrides of notebook CSS for static HTML export */
+body {
+  overflow: visible;
+  padding: 8px;
+}
+
+div#notebook {
+  overflow: visible;
+  border-top: none;
+}
+
+@media print {
+  div.cell {
+    display: block;
+    page-break-inside: avoid;
+  }
+  div.output_wrapper {
+    display: block;
+    page-break-inside: avoid;
+  }
+  div.output {
+    display: block;
+    page-break-inside: avoid;
+  }
+}
+</style>
+
+<!-- Custom stylesheet, it must be in the same directory as the html file -->
+<link rel="stylesheet" href="custom.css">
+
+<!-- Loading mathjax macro -->
+{{ mathjax() }}
+
+</head>
+{%- endblock header -%}
+
+{% block body %}
+<body>
+  <div tabindex="-1" id="notebook" class="border-box-sizing">
+    <div class="container" id="notebook-container">
+{{ super() }}
+    </div>
+  </div>
+</body>
+{%- endblock body %}
+
+{% block footer %}
+</html>
+{% endblock footer %}

--- a/doc/jsdoc_config.json
+++ b/doc/jsdoc_config.json
@@ -1,0 +1,37 @@
+{
+    "source": {
+        "include": [ "lib" ],
+        "includePattern": ".+\\.js(doc)?$"
+    },
+    "opts": {
+        "template": "node_modules/ink-docstrap/template",
+        "readme": "doc/README.md",
+        "destination": "doc/output",
+        "tutorials": "doc/tutorials"
+    },
+    "tags": {
+        "allowUnknownTags": true
+    },
+    "plugins": ["plugins/markdown"],
+    "templates": {
+        "cleverLinks": false,
+        "monospaceLinks": false,
+        "dateFormat": "ddd MMM Do YYYY",
+        "outputSourceFiles": true,
+        "outputSourcePath": true,
+        "systemName": "ijavascript",
+        "footer": "",
+        "copyright": "ijavascript Copyright © 2015, Nicolas Riesco and others as credited <a href='https://github.com/n-riesco/ijavascript/blob/master/AUTHORS'>here</a>.",
+        "navType": "inline",
+        "theme": "cosmo",
+        "linenums": true,
+        "collapseSymbols": false,
+        "inverseNav": true,
+        "highlightTutorialCode": false,
+        "protocol": "html://"
+    },
+    "markdown": {
+        "parser": "gfm",
+        "hardwrap": true
+    }
+    }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "zmq": "^2.10.0"
     },
     "devDependencies": {
+        "ink-docstrap": "latest",
         "jsdoc": "latest",
         "jshint": "latest"
     },

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     },
     "scripts": {
         "doc": "npm run doc:nb && npm run doc:jsdoc && npm run doc:images",
-        "doc:nb": "ipython nbconvert 'doc/tutorials/*.ipynb' --FilesWriter.build_directory='doc/tutorials'",
-        "doc:jsdoc": "jsdoc -R doc/README.md -u doc/tutorials -d doc/output lib",
+        "doc:nb": "ipython nbconvert --template 'doc/ipython' 'doc/tutorials/*.ipynb' --FilesWriter.build_directory='doc/tutorials'",
+        "doc:jsdoc": "jsdoc -c ./doc/jsdoc_config.json",
         "doc:images": "node script/doc-images.js",
         "doc:publish": "node script/doc-publish.js doc/output https://github.com/n-riesco/ijavascript",
         "lint": "jshint bin lib"


### PR DESCRIPTION
Hi Nico, I worked on the documentation layout, you can see the result here: <http://benjaminabel.github.io/ijavascript/>

It uses docstrap as a dependencie, which include bootstrap, so I worked on a ipython template to remove duplicate css. 

Are you Ok, or would you like that I work on docstrap templates including them in the repo?