### PR TITLE
Fixes for Hydrogen compatibility

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@ Benjamin Abel <bbig26@gmail.com>
 Kevin Kwok <kkwok@mit.edu>
 Min RK <benjaminrk@gmail.com>
 Nicolas Riesco <enquiries@nicolasriesco.net>
+Will Whitney <wfwhitney@gmail.com>

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -194,10 +194,7 @@ function Kernel(ipythonConfig, smConfig, protocolVersion) {
             this.config.key
         );
 
-        if (!msg.signatureOK) {
-            console.error("KERNEL: Incorrect message signature: " + msg.signature);
-            return;
-        }
+        if (!msg.signatureOK) return;
 
         var msg_type = msg.header.msg_type;
         if (this.handlers.hasOwnProperty(msg_type)) {

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -194,7 +194,10 @@ function Kernel(ipythonConfig, smConfig, protocolVersion) {
             this.config.key
         );
 
-        if (!msg.signatureOK) return;
+        if (!msg.signatureOK) {
+            console.error("KERNEL: Incorrect message signature: " + msg.signature);
+            return;
+        }
 
         var msg_type = msg.header.msg_type;
         if (this.handlers.hasOwnProperty(msg_type)) {

--- a/lib/sm_server.js
+++ b/lib/sm_server.js
@@ -152,7 +152,6 @@
         return response ? response : {
             mime: {
                 "text/plain": util.inspect(result),
-                "text/html": toHtml(result),
             }
         };
 


### PR DESCRIPTION
- Added an error message if the signature is incorrect (previously it was just swallowed)
- Eliminated the signature check if key = ""
  - This was done before with `(this.signature === '')`, but it didn't actually work
- Only respond with HTML if the content is really HTML
  - response types like HTML are meant for progressive enhancement; they aren't required and shouldn't be used unless necessary