### PR TITLE
Prepend dot to file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ other languages](https://github.com/ipython/ipython/wiki/IPython-kernels-for-oth
   `HTML`, `SVG`, `PNG`, ...
 - [Asynchronous
   output](http://n-riesco.github.io/ijavascript/doc/async.ipynb.html)
+- [Customised
+  output](http://n-riesco.github.io/ijavascript/doc/mimer.ipynb.html)
 - [Autocompletion](http://n-riesco.github.io/ijavascript/doc/complete.md.html):
   press `TAB` to complete keywords and object properties
 - [Object

--- a/bin/ijavascript.js
+++ b/bin/ijavascript.js
@@ -60,10 +60,12 @@ var usage = (
     "    --ijs-install=[local|global]  install IJavascript kernel\n" +
     "    --ijs-install-kernel          same as --ijs-install=local\n" +
     "                                  (for backwards-compatibility)\n" +
-    "    --ijs-protocol=version  set protocol version, e.g. 4.1\n" +
+    "    --ijs-protocol=version        set protocol version, e.g. 4.1\n" +
+    "    --ijs-startup-script=path     run script on startup\n" +
+    "                                  (path can be a file or a folder)\n" +
     "    --ijs-working-dir=path  set Javascript session working directory\n" +
     "                            (default = current working directory)\n" +
-    "    --version               show IJavascript version\n" +
+    "    --version                     show IJavascript version\n" +
     "\n" +
     "and any other options recognised by the IPython notebook; run:\n" +
     "\n" +
@@ -86,6 +88,7 @@ var usage = (
  * @property {Boolean}  context.flag.debug    --ijs-debug
  * @property {String}   context.flag.install  --ijs-install=[local|global]
  * @property {String}   context.flag.cwd      --ijs-working-dir=path
+ * @property {String}   context.flag.startup  --ijs-startup-script=path
  * @property            context.args
  * @property {String[]} context.args.kernel   Command arguments to run kernel
  * @property {String[]} context.args.frontend Command arguments to run frontend
@@ -182,6 +185,9 @@ function parseCommandArgs(context) {
                 context.protocol.version.split(".", 1)[0]
             );
 
+        } else if (e.lastIndexOf("--ijs-startup-script=", 0) === 0) {
+            context.flag.startup = fs.realpathSync(e.slice(21));
+
         } else if (e.lastIndexOf("--ijs-working-dir=", 0) === 0) {
             context.flag.cwd = fs.realpathSync(e.slice(18));
 
@@ -201,6 +207,10 @@ function parseCommandArgs(context) {
             context.args.frontend.push(e);
         }
     });
+
+    if (context.flag.startup) {
+        context.args.kernel.push("--startup-script=" + context.flag.startup);
+    }
 
     if (context.flag.cwd) {
         context.args.kernel.push("--session-working-dir=" + context.flag.cwd);

--- a/doc/mimer.ipynb
+++ b/doc/mimer.ipynb
@@ -1,0 +1,260 @@
+{
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Javascript (Node.js)",
+   "language": "javascript",
+   "name": "javascript"
+  },
+  "language_info": {
+   "file_extension": "js",
+   "mimetype": "application/javascript",
+   "name": "javascript",
+   "version": "0.10.25"
+  },
+  "name": ""
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "# Customised Output\n",
+      "\n",
+      "By default, the IJavascript kernel returns plain text outputs. The function used to convert a result into a MIME representation is available via the global variable `$$mimer$$`. The below code illustrates how it works:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "$$mimer$$(\"Hello, world!\");"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "metadata": {},
+       "output_type": "pyout",
+       "prompt_number": 1,
+       "text": [
+        "{ 'text/plain': '\\'Hello, world!\\'' }"
+       ]
+      }
+     ],
+     "prompt_number": 1
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "`$$mimer$$` can be redefined to return alternative MIME representations. The following examples progress from a simple `$$mimer$$` that adds a `text/html` MIME representation to a `$$mimer$$` that customises the output of specific class instances."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "## Simple `text/html` `$$mimer$$`\n",
+      "\n",
+      "This `$$mimer$$` invokes the default `$$mimer$$`. If the default `$$mimer$$` doesn't return a `text/html` MIME representation, it generates one by surrounding the `text/plain` MIME representation within a `<pre>` tag."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "var defaultMimer = $$mimer$$;\n",
+      "\n",
+      "function htmlMimer(object) {\n",
+      "    var mime  = defaultMimer(object);\n",
+      "\n",
+      "    if (!(\"text/html\" in mime) && (\"text/plain\" in mime)) {\n",
+      "        mime[\"text/html\"] = (\n",
+      "            \"<pre>\" +\n",
+      "            mime[\"text/plain\"].replace(/\\\\n/g, '\\n').\n",
+      "                               replace(/&/g, '&amp;').\n",
+      "                               replace(/</g, '&lt;').\n",
+      "                               replace(/>/g, '&gt;').\n",
+      "                               replace(/\\\"/g, '&quot;').\n",
+      "                               replace(/\\'/g, '&#39;') +\n",
+      "            \"</pre>\"\n",
+      "        );\n",
+      "    }\n",
+      "    \n",
+      "    return mime;\n",
+      "}\n",
+      "\n",
+      "$$mimer$$ = htmlMimer;\n",
+      "\n",
+      "$$mimer$$(\"Hello, World!\");"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "html": [
+        "<pre>{ &#39;text/plain&#39;: &#39;\\&#39;Hello, World!\\&#39;&#39;,\n",
+        "  &#39;text/html&#39;: &#39;&lt;pre&gt;&amp;#39;Hello, World!&amp;#39;&lt;/pre&gt;&#39; }</pre>"
+       ],
+       "metadata": {},
+       "output_type": "pyout",
+       "prompt_number": 2,
+       "text": [
+        "{ 'text/plain': '\\'Hello, World!\\'',\n",
+        "  'text/html': '<pre>&#39;Hello, World!&#39;</pre>' }"
+       ]
+      }
+     ],
+     "prompt_number": 2
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "## `$$defaultMimer$$`\n",
+      "\n",
+      "For convenience, the default `$$mimer$$` is always accessible via the immutable global `$$defaultMimer$$`. This allows the default `$$mimer$$` to be restored by running:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "$$mimer$$ = $$defaultMimer$$;\n",
+      "\n",
+      "$$mimer$$(\"Hello, World!\");"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "metadata": {},
+       "output_type": "pyout",
+       "prompt_number": 3,
+       "text": [
+        "{ 'text/plain': '\\'Hello, World!\\'' }"
+       ]
+      }
+     ],
+     "prompt_number": 3
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "## Styled `text/html` `$$mimer$$`\n",
+      "\n",
+      "Here's another example that extends `htmlMimer()` to produce styled `text.html` outputs:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "function styledMimer(object) {\n",
+      "    var mime  = htmlMimer(object);\n",
+      "\n",
+      "    if (\"text/html\" in mime) {\n",
+      "        mime[\"text/html\"] = \"<div style='border: 1px solid grey; \" +\n",
+      "                                        \"border-radius: .3em; \" +\n",
+      "                                        \"padding: .3em; \" +\n",
+      "                                        \"background-color: gainsboro; \" +\n",
+      "                                        \"font-weight: bold; \" +\n",
+      "                                        \"font-style: italic;'>\" +\n",
+      "                            mime[\"text/html\"] +\n",
+      "                            \"</div>\";\n",
+      "    }\n",
+      "\n",
+      "    return mime;\n",
+      "}\n",
+      "\n",
+      "$$mimer$$ = styledMimer;\n",
+      "\n",
+      "$$mimer$$(\"Hello, World!\");"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "html": [
+        "<div style='border: 1px solid grey; border-radius: .3em; padding: .3em; background-color: gainsboro; font-weight: bold; font-style: italic;'><pre>{ &#39;text/plain&#39;: &#39;\\&#39;Hello, World!\\&#39;&#39;,\n",
+        "  &#39;text/html&#39;: &#39;&lt;div style=\\&#39;border: 1px solid grey; border-radius: .3em; padding: .3em; background-color: gainsboro; font-weight: bold; font-style: italic;\\&#39;&gt;&lt;pre&gt;&amp;#39;Hello, World!&amp;#39;&lt;/pre&gt;&lt;/div&gt;&#39; }</pre></div>"
+       ],
+       "metadata": {},
+       "output_type": "pyout",
+       "prompt_number": 4,
+       "text": [
+        "{ 'text/plain': '\\'Hello, World!\\'',\n",
+        "  'text/html': '<div style=\\'border: 1px solid grey; border-radius: .3em; padding: .3em; background-color: gainsboro; font-weight: bold; font-style: italic;\\'><pre>&#39;Hello, World!&#39;</pre></div>' }"
+       ]
+      }
+     ],
+     "prompt_number": 4
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "## Customised output for specific instances\n",
+      "\n",
+      "This last example implements a `$$mimer$$` that generates a customised output for instances of class `Person`:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "function Person(name, surname) {\n",
+      "    this.name = name;\n",
+      "    this.surname = surname;\n",
+      "}\n",
+      "\n",
+      "var person = new Person(\"Edwin\", \"Jaynes\");\n",
+      "\n",
+      "function personMimer(object) {\n",
+      "    var mime = personMimer.previousMimer(object);\n",
+      "    \n",
+      "    if (object instanceof Person) {\n",
+      "        mime[\"text/html\"] = \"<table style=\\\"border: 1px solid black;\" +\n",
+      "                                           \"border-spacing: .3em;\" + \n",
+      "                                           \"border-collapse: separate;\\\">\" +\n",
+      "                            \"<tr><th>Name<td>\" + object.name +\n",
+      "                            \"<tr><th>Surname<td>\" + object.surname +\n",
+      "                            \"</table>\";\n",
+      "    }\n",
+      "    \n",
+      "    return mime;\n",
+      "}\n",
+      "\n",
+      "personMimer.previousMimer = $$mimer$$;\n",
+      "\n",
+      "$$mimer$$ = personMimer;\n",
+      "\n",
+      "person;"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "html": [
+        "<table style=\"border: 1px solid black;border-spacing: .3em;border-collapse: separate;\"><tr><th>Name<td>Edwin<tr><th>Surname<td>Jaynes</table>"
+       ],
+       "metadata": {},
+       "output_type": "pyout",
+       "prompt_number": 5,
+       "text": [
+        "{ name: 'Edwin', surname: 'Jaynes' }"
+       ]
+      }
+     ],
+     "prompt_number": 5
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}

--- a/doc/navbar.json
+++ b/doc/navbar.json
@@ -5,8 +5,9 @@
         "01. Text output": "hello.ipynb",
         "02. Graphical output": "graphics.ipynb",
         "03. Asynchronous output": "async.ipynb",
-        "04. TAB completion": "complete.md",
-        "05. Shift-TAB inspection": "inspect.md"
+        "04. Customised output": "mimer.ipynb",
+        "05. TAB completion": "complete.md",
+        "06. Shift-TAB inspection": "inspect.md"
     },
     "Tutorials": {
         "N. Riesco": {

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -1,21 +1,20 @@
 # Usage
 
-To start an IPython notebook session with the IJavascript kernel, simply run:
+To start an IJavascript session in the Jupyter notebook, simply run:
 
 ```sh
 ijs
 ```
 
-This command should open the IPython notebook dashboard in your default web
-browser:
+This command will open the Jupyter dashboard in your default web browser:
 
 ![Screenshot: IPython Notebook
 Dashboard](../images/screenshot-dashboard-home.png)
 
 ## Register IJavascript with the dashboard
 
-The IJavascript kernel can be registered with IPython v3 without opening the
-dashboard. To register the kernel for all users, run:
+The IJavascript kernel can be registered with Jupyter (and IPython v3) without
+opening the dashboard. To register the kernel for all users, run:
 
 ```sh
 ijs --ijs-install=global
@@ -40,7 +39,7 @@ ijs --notebook-dir=path/to/another/folder
 ![Screenshot: IPython Notebook
 --notebook-dir](../images/screenshot-dashboard-dir.png)
 
-## Set the working folder
+## Set the kernel working folder
 
 Also by default, the IJavascript kernel runs a `node.js` session in the current
 working folder. The flag `--ijs-working-dir=path/to/another/folder` can be used
@@ -48,6 +47,27 @@ to run the `node.js` session at a different folder.
 
 ![Screenshot: IPython Notebook
 --ijs_working-dir](../images/screenshot-notebook-dir.png)
+
+## Run startup scripts
+
+It is possible to run one or more scripts at the startup of an IJavascript
+session. This can be useful to preload an `npm` package (e.g.
+[d3](https://www.npmjs.com/package/d3)) or a [custom
+`$$mimer$$`](http://n-riesco.github.io/ijavascript/doc/mimer.ipynb.html).
+
+To preload a script:
+
+```sh
+ijs --ijs-startup-script=path/to/script.js
+```
+
+For convenience, it is also possible to preload all the Javascript files in a
+folder. The execution order is determined by the alphabetical order of their
+filenames; for example: `50-package-d3.js`, `60-mimer-d3.js`.
+
+```sh
+ijs --ijs-startup-script=path/to/folder
+```
 
 ## Other command flags
 

--- a/lib/handlers_v5.js
+++ b/lib/handlers_v5.js
@@ -84,7 +84,7 @@ function kernel_info_request(request) {
                 "name": "javascript",
                 "version": nodeVersion,
                 "mimetype": "application/javascript",
-                "file_extension": "js",
+                "file_extension": ".js",
             },
             "banner": (
                 "IJavascript v" + ijsVersion + "\n" +

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -392,6 +392,8 @@ Kernel.prototype._runStartupScripts = function() {
         } else {
             startupScripts = [];
         }
+    } else {
+            startupScripts = [];
     }
 
     if (DEBUG) console.log("KERNEL: STARTUP: " + startupScripts);

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -38,6 +38,7 @@ var DEBUG = false;
 
 var console = require("console");
 var fs = require("fs");
+var path = require("path");
 var util = require("util");
 
 // Parse command arguments
@@ -50,20 +51,25 @@ var config = {
 var usage = (
     "Usage: node kernel.js " +
     "[--debug] " +
-    "[--protocol=Major[.minor[.patch]]] " +
-    "[--session-working-dir=path " +
     "[--hide-undefined] " +
+    "[--protocol=Major[.minor[.patch]]] " +
+    "[--session-working-dir=path] " +
+    "[--startup-script=path] " +
     "connection_file"
 );
 
 var FLAG_DEBUG = "--debug";
+var FLAG_HIDE_UNDEFINED = "--hide-undefined";
 var FLAG_PROTOCOL = "--protocol=";
 var FLAG_CWD = "--session-working-dir=";
-var FLAG_HIDE_UNDEFINED = "--hide-undefined";
+var FLAG_STARTUP_SCRIPT = "--startup-script=";
 try {
     process.argv.slice(2).forEach(function(arg) {
         if (arg === FLAG_DEBUG) {
             DEBUG = true;
+
+        } else if (arg === FLAG_HIDE_UNDEFINED) {
+            config.hideUndefined = true;
 
         } else if (arg.slice(0, FLAG_PROTOCOL.length) === FLAG_PROTOCOL) {
             config.protocolVersion = arg.slice(FLAG_PROTOCOL.length);
@@ -71,8 +77,9 @@ try {
         } else if (arg.slice(0, FLAG_CWD.length) === FLAG_CWD) {
             config.nel.cwd = arg.slice(FLAG_CWD.length);
 
-        } else if (arg === FLAG_HIDE_UNDEFINED) {
-            config.hideUndefined = true;
+        } else if (
+            arg.slice(0, FLAG_STARTUP_SCRIPT.length) === FLAG_STARTUP_SCRIPT) {
+            config.startupScript = arg.slice(FLAG_STARTUP_SCRIPT.length);
 
         } else if (!config.connection) {
             config.connection = fs.readFileSync(arg);
@@ -112,6 +119,12 @@ var zmq = require("jmp").zmq; // ZMQ bindings
  * @param {module:nel~Config} config.nel   Javascript session configuration.
  *
  * @param {String}  config.protocolVersion IPython/Jupyter protocol version.
+ *
+ * @param {String}  config.startupScript   Path to a Javascript file to be run
+ *                                         on session startup. Path to a folder
+ *                                         also accepted, in which case all the
+ *                                         Javascript files in the folder will
+ *                                         be run.
  */
 function Kernel(config) {
     /**
@@ -159,6 +172,14 @@ function Kernel(config) {
     this.session = new Session(config.nel);
 
     /**
+     * Path to a Javascript file to be run on session startup. Path to a folder
+     * also accepted, in which case all the Javascript files in the folder will
+     * be run.
+     * @member {String}
+     */
+    this.startupScript = config.startupScript;
+
+    /**
      * Number of visible execution requests
      * @member {Number}
      */
@@ -188,80 +209,10 @@ function Kernel(config) {
         require("./handlers_v4.js") :
         require("./handlers_v5.js");
 
-    this._relayStandardStreams();
-
     this._bindSockets();
+
+    this._initSession();
 }
-
-/**
- * Hook listeners to relay the standard streams onto the IOPub socket
- *
- * @private
- */
-Kernel.prototype._relayStandardStreams = function() {
-    var majorVersion = parseInt(this.protocolVersion.split(".")[0]);
-
-    var onStdout = (majorVersion <= 4) ? onStdoutV4 : onStdoutV5;
-    var onStderr = (majorVersion <= 4) ? onStderrV4 : onStderrV5;
-    this.session.stdout.on("data", onStdout.bind(this));
-    this.session.stderr.on("data", onStderr.bind(this));
-
-    function onStdoutV4(data) {
-        if (DEBUG) console.log("KERNEL: STDOUT: ", data.toString());
-
-        if (this.lastExecuteRequest) {
-            this.lastExecuteRequest.respond(
-                this.iopubSocket,
-                "stream", {
-                    name: "stdout",
-                    data: data.toString(),
-                }
-            );
-        }
-    }
-
-    function onStderrV4(data) {
-        if (DEBUG) console.log("KERNEL: STDERR: ", data.toString());
-
-        if (this.lastExecuteRequest) {
-            this.lastExecuteRequest.respond(
-                this.iopubSocket,
-                "stream", {
-                    name: "stderr",
-                    data: data.toString(),
-                }
-            );
-        }
-    }
-
-    function onStdoutV5(data) {
-        if (DEBUG) console.log("KERNEL: STDOUT: ", data.toString());
-
-        if (this.lastExecuteRequest) {
-            this.lastExecuteRequest.respond(
-                this.iopubSocket,
-                "stream", {
-                    name: "stdout",
-                    text: data.toString(),
-                }
-            );
-        }
-    }
-
-    function onStderrV5(data) {
-        if (DEBUG) console.log("KERNEL: STDERR: ", data.toString());
-
-        if (this.lastExecuteRequest) {
-            this.lastExecuteRequest.respond(
-                this.iopubSocket,
-                "stream", {
-                    name: "stderr",
-                    text: data.toString(),
-                }
-            );
-        }
-    }
-};
 
 /**
  * Bind kernel sockets and hook listeners
@@ -337,6 +288,142 @@ Kernel.prototype._bindSockets = function() {
 };
 
 /**
+ * Initialise session
+ *
+ * @private
+ */
+Kernel.prototype._initSession = function() {
+    this._relayStandardStreams();
+    this._runStartupScripts();
+};
+
+/**
+ * Hook listeners to relay the standard streams onto the IOPub socket
+ *
+ * @private
+ */
+Kernel.prototype._relayStandardStreams = function() {
+    var majorVersion = parseInt(this.protocolVersion.split(".")[0]);
+
+    var onStdout = (majorVersion <= 4) ? onStdoutV4 : onStdoutV5;
+    var onStderr = (majorVersion <= 4) ? onStderrV4 : onStderrV5;
+    this.session.stdout.on("data", onStdout.bind(this));
+    this.session.stderr.on("data", onStderr.bind(this));
+
+    function onStdoutV4(data) {
+        if (DEBUG) console.log("KERNEL: STDOUT: ", data.toString());
+
+        if (this.lastExecuteRequest) {
+            this.lastExecuteRequest.respond(
+                this.iopubSocket,
+                "stream", {
+                    name: "stdout",
+                    data: data.toString(),
+                }
+            );
+        }
+    }
+
+    function onStderrV4(data) {
+        if (DEBUG) console.log("KERNEL: STDERR: ", data.toString());
+
+        if (this.lastExecuteRequest) {
+            this.lastExecuteRequest.respond(
+                this.iopubSocket,
+                "stream", {
+                    name: "stderr",
+                    data: data.toString(),
+                }
+            );
+        }
+    }
+
+    function onStdoutV5(data) {
+        if (DEBUG) console.log("KERNEL: STDOUT: ", data.toString());
+
+        if (this.lastExecuteRequest) {
+            this.lastExecuteRequest.respond(
+                this.iopubSocket,
+                "stream", {
+                    name: "stdout",
+                    text: data.toString(),
+                }
+            );
+        }
+    }
+
+    function onStderrV5(data) {
+        if (DEBUG) console.log("KERNEL: STDERR: ", data.toString());
+
+        if (this.lastExecuteRequest) {
+            this.lastExecuteRequest.respond(
+                this.iopubSocket,
+                "stream", {
+                    name: "stderr",
+                    text: data.toString(),
+                }
+            );
+        }
+    }
+};
+
+/**
+ * Run startup scripts
+ *
+ * @private
+ */
+Kernel.prototype._runStartupScripts = function() {
+    var startupScripts;
+
+    if (this.startupScript) {
+        var stats = fs.lstatSync(this.startupScript);
+        if (stats.isDirectory()) {
+            var dir = this.startupScript;
+            startupScripts = fs.readdirSync(dir).filter(function(filename) {
+                var ext = filename.slice(filename.length - 3).toLowerCase();
+                return ext === ".js";
+            }).sort().map(function(filename) {
+                return path.join(dir, filename);
+            });
+
+        } else if (stats.isFile()) {
+            startupScripts = [this.startupScript];
+
+        } else {
+            startupScripts = [];
+        }
+    }
+
+    if (DEBUG) console.log("KERNEL: STARTUP: " + startupScripts);
+
+    startupScripts.forEach((function(script) {
+        var code;
+
+        try {
+            code = fs.readFileSync(script).toString();
+        } catch (e) {
+            var msg = "KERNEL: STARTUP: Cannot read '" + script + "'";
+            if (DEBUG) console.log(msg);
+            return;
+        }
+
+        var task = {
+            action: "run",
+            code: code,
+            onSuccess: function() {
+                var msg = "KERNEL: STARTUP: '" + script + "' run successfuly";
+                if (DEBUG) console.log(msg);
+            },
+            onError: function() {
+                var msg = "KERNEL: STARTUP: '" + script + "' failed to run";
+                if (DEBUG) console.log(msg);
+            },
+        };
+        this.session.run(task);
+    }).bind(this));
+};
+
+/**
  * Destroy kernel
  *
  * @param {DestroyCB} [destroyCB] Callback run after the session server has been
@@ -382,7 +469,7 @@ Kernel.prototype.restart = function(restartCB) {
     if (DEBUG) console.log("KERNEL: Being restarted");
 
     this.session.restart("SIGTERM", (function() {
-        this._relayStandardStreams();
+        this._initSession();
         if (restartCB) {
             restartCB();
         }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     },
     "dependencies": {
         "jmp": "0.2.x",
-        "nel": "0.1.x",
+        "nel": "0.2.x",
         "node-uuid": "^1.4.2"
     },
     "devDependencies": {


### PR DESCRIPTION
[Per the Jupyter Messaging spec](http://jupyter-client.readthedocs.org/en/latest/messaging.html#kernel-info), the file extension in a `kernel_info_reply` needs to include the `.`.

Noticed this while hacking around with an experimental client.

![screenshot 2016-01-17 23 56 59](https://cloud.githubusercontent.com/assets/836375/12384297/d126816c-bd75-11e5-9cab-2369a7f903e2.png)
