### PR TITLE
Updated OSX install instructions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@
 
 Benjamin Abel <bbig26@gmail.com>
 Kevin Kwok <kkwok@mit.edu>
+Mandar Vaze <mandarvaze@gmail.com>
 Min RK <benjaminrk@gmail.com>
 Nicolas Riesco <enquiries@nicolasriesco.net>
 Will Whitney <wfwhitney@gmail.com>

--- a/doc/install.md
+++ b/doc/install.md
@@ -75,7 +75,7 @@ instructions below work as intended:
 ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 brew install pkg-config node zeromq
 sudo easy_install pip
-sudo pip install --upgrade ipython jinja2 tornado jsonschema pyzmq
+sudo pip install -U jupyter  # Refer http://jupyter.readthedocs.org/en/latest/install.html
 ```
 
 Once the dependencies have been installed, `npm` can be used to install


### PR DESCRIPTION
``pip3 install -U jupyter`` installs the other dependencies like ``jsonschema, pyzmq, jinja2`` etc. automatically
I've successfully installed ijavascript on OSX (El Capitan) using these instructions.