### PR TITLE
Fix loading package.json to find version

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,3 +12,4 @@ Mandar Vaze <mandarvaze@gmail.com>
 Min RK <benjaminrk@gmail.com>
 Nicolas Riesco <enquiries@nicolasriesco.net>
 Will Whitney <wfwhitney@gmail.com>
+Matt Torok <github@overblown.net>

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -36,6 +36,7 @@
 
 var console = require("console");
 var fs = require("fs");
+var path = require("path");
 
 var Kernel = require("jp-kernel");
 
@@ -177,7 +178,7 @@ function parseCommandArguments() {
     } else {
         nodeVersion = process.versions.node;
         protocolVersion = config.protocolVersion;
-        ijsVersion = JSON.parse(fs.readFileSync("package.json")).version;
+        ijsVersion = JSON.parse(fs.readFileSync(path.join(__dirname, ".." , "package.json"))).version;
         config.kernelInfoReply = {
             "protocol_version": protocolVersion,
             "implementation": "ijavascript",

--- a/test/index.js
+++ b/test/index.js
@@ -884,7 +884,7 @@ function testKernelInfoRequest(context) {
 
             assert.strictEqual(
                 response.content.implementation_version,
-                JSON.parse(fs.readFileSync("package.json")).version,
+                JSON.parse(fs.readFileSync(path.join(__dirname, ".." , "package.json"))).version;
                 "Error in content.implementation_version: " +
                 util.inspect(response.content)
             );


### PR DESCRIPTION
In `lib/kernel.js`, line 183 tries to load ijavascript's `package.json` file to find the current version number. However, if $PWD isn't the ijavascript module folder, this will fail with a "file not found" error.

This commit changes that line so that it tries to load `__dirname/../package.json` (using the `path.join()` utility for cross-platform portability).