### PR TITLE
Add "is_complete_request" message handler

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,6 +7,7 @@
 # Please keep the list sorted.
 
 Benjamin Abel <bbig26@gmail.com>
+Frankie Dintino <fdintino@gmail.com>
 Kevin Kwok <kkwok@mit.edu>
 Mandar Vaze <mandarvaze@gmail.com>
 Matt Torok <github@overblown.net>

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -37,6 +37,7 @@
 var console = require("console");
 var fs = require("fs");
 var path = require("path");
+var esprima = require('esprima');
 
 var Kernel = require("jp-kernel");
 
@@ -197,6 +198,23 @@ function parseCommandArguments() {
                 "text": "IJavascript Homepage",
                 "url": "https://github.com/n-riesco/ijavascript",
             }],
+        };
+        config.handlers = {
+            is_complete_request: function(request) {
+                var status = "complete";
+                try {
+                    esprima.parse(request.content.code);
+                } catch(e) {
+                    if (e.message.indexOf("Unexpected end of input") > -1) {
+                        status = "incomplete";
+                    } else {
+                        status = "invalid";
+                    }
+                }
+                request.respond(this.shellSocket, "is_complete_reply", {
+                    status: status,
+                });
+            },
         };
     }
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "ijs": "bin/ijavascript.js"
     },
     "dependencies": {
+        "esprima": "^3.0.0",
         "jp-kernel": "0.0.x"
     },
     "devDependencies": {


### PR DESCRIPTION
This pull request adds a javascript-kernel-specific "is_complete_reply" message handler. It depends on n-riesco/jp-kernel#2

This code was originally part of n-riesco/jp-kernel#1
