### PR TITLE
feat(bin): provide ijskernel as bin

### DIFF
--- a/bin/ijavascript.js
+++ b/bin/ijavascript.js
@@ -170,8 +170,7 @@ function readPackageJson(context) {
 
 function parseCommandArgs(context) {
     context.args.kernel = [
-        context.path.node,
-        context.path.kernel,
+        (process.platform === 'win32') ? 'ijskernel.cmd' : 'ijskernel',
     ];
     context.args.frontend = [
         "jupyter",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
         "url": "https://github.com/n-riesco/ijavascript.git"
     },
     "bin": {
-        "ijs": "bin/ijavascript.js"
+        "ijs": "bin/ijavascript.js",
+        "ijskernel": "lib/kernel.js"
     },
     "dependencies": {
         "jp-kernel": "0.0.x"


### PR DESCRIPTION
This makes it so that `ijskernel` can be used directly as a bin script, which makes my local kernel.json _much_ easier to work with when I'm changing node versions:

``` json
{
  "argv": [
    "ijskernel",
    "{connection_file}",
    "--protocol=5.0"
  ],
  "display_name": "Javascript (Node.js)",
  "language": "javascript"
}
```

For me, this makes #67 much easier to deal with. _Now_, every time I upgrade node with `nvm`, I globally install `ijavascript` again and it _just works_ because it's not reliant on a hardcoded path to my node version + the library location.

On windows, the kernelspec is:

``` json
{
  "argv": [
    "ijskernel.cmd",
    "{connection_file}",
    "--protocol=5.0"
  ],
  "display_name": "Javascript (Node.js)",
  "language": "javascript"
}
```

/cc @thisgeek @c22 
