### PR TITLE
chore: switch dependency to uuid (relied on by jmp)

### DIFF
--- a/bin/ijavascript.js
+++ b/bin/ijavascript.js
@@ -42,7 +42,7 @@ var path = require("path");
 var spawn = require("child_process").spawn;
 var util = require("util");
 
-var uuid = require("node-uuid");
+var uuid = require("uuid");
 
 var usage = [
     "IJavascript Notebook",
@@ -252,7 +252,7 @@ function parseCommandArgs(context) {
             console.log("ijavascript", context.packageJSON.version);
             console.log("jmp", getPackageVersion("jmp"));
             console.log("nel", getPackageVersion("nel"));
-            console.log("node-uuid", getPackageVersion("node-uuid"));
+            console.log("uuid", getPackageVersion("uuid"));
             process.exit(0);
 
         } else {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
         "ijskernel": "lib/kernel.js"
     },
     "dependencies": {
-        "jp-kernel": "0.1.x"
+        "jp-kernel": "0.1.x",
+        "uuid": "^3.0.1"
     },
     "devDependencies": {
         "debug": "latest",

--- a/test/mte/index.js
+++ b/test/mte/index.js
@@ -43,7 +43,7 @@ var fs = require("fs");
 var path = require("path");
 var util = require("util");
 var spawn = require("child_process").spawn;
-var uuid = require("node-uuid");
+var uuid = require("uuid");
 
 var jmp = require("jmp");
 var zmq = jmp.zmq;


### PR DESCRIPTION
Since `node-uuid` is deprecated, `jmp` has adapted to `uuid`, and `ijavascript` had an implicit dependency on `node-uuid` I took the effort of getting this overall package upgraded and pinned.

Fixes #88.