### PR TITLE
Add missing main file to package.json

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@
 
 Benjamin Abel <bbig26@gmail.com>
 Kevin Kwok <kkwok@mit.edu>
+Lukas Geiger <lukas.geiger94@gmail.com>
 Mandar Vaze <mandarvaze@gmail.com>
 Matt Torok <github@overblown.net>
 Min RK <benjaminrk@gmail.com>

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "ijs": "bin/ijavascript.js",
         "ijskernel": "lib/kernel.js"
     },
+    "main": "lib/kernel.js",
     "dependencies": {
         "jp-kernel": "0.1.x"
     },


### PR DESCRIPTION
We want to ship a bundled version of `ijavascript` with `nteract` using Node.js from Electron: https://github.com/nteract/nteract/pull/1339

This will allow us to use `require.resolve('ijavascript')` to obtain the file path. Otherwise the require call will fail because no main file is specified.