### PR TITLE
Run tests on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os: linux
 language: node_js
 node_js:
   - "0.10"
-  - "0.12"
   - "4"
   - "5"
   - "6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: false
+os: linux
+language: node_js
+node_js:
+  - "0.10"
+  - "0.12"
+  - "4"
+  - "5"
+  - "6"
+  - "7"

--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@
 
 Benjamin Abel <bbig26@gmail.com>
 Kevin Kwok <kkwok@mit.edu>
+Lukas Geiger <lukas.geiger94@gmail.com>
 Mandar Vaze <mandarvaze@gmail.com>
 Matt Torok <github@overblown.net>
 Min RK <benjaminrk@gmail.com>

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     },
     "devDependencies": {
         "debug": "latest",
+        "jmp": "^0.7.5",
         "jsdoc": "latest",
         "jshint": "latest",
         "mocha": "3",


### PR DESCRIPTION
Currently the tests fail on CI and probably show the failure described in https://github.com/nteract/hydrogen/issues/591.

Here is a link to the CI build: https://travis-ci.org/lgeiger/ijavascript/builds/213530243

@n-riesco It would be great if you could enable Travis for this repository so tests are run on every commit and PR.