### PR TITLE
Revert "Run tests on Travis CI"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-sudo: false
-os: linux
-language: node_js
-node_js:
-  - "0.10"
-  - "4"
-  - "5"
-  - "6"
-  - "7"

--- a/AUTHORS
+++ b/AUTHORS
@@ -8,7 +8,6 @@
 
 Benjamin Abel <bbig26@gmail.com>
 Kevin Kwok <kkwok@mit.edu>
-Lukas Geiger <lukas.geiger94@gmail.com>
 Mandar Vaze <mandarvaze@gmail.com>
 Matt Torok <github@overblown.net>
 Min RK <benjaminrk@gmail.com>

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     },
     "devDependencies": {
         "debug": "latest",
-        "jmp": "^0.7.5",
         "jsdoc": "latest",
         "jshint": "latest",
         "mocha": "3",


### PR DESCRIPTION
Reverts n-riesco/ijavascript#99

* jp-kernel@0.1.2 doesn't fix the test failure in Travis