### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ In macOS, [Homebrew](http://brew.sh/) and
 IJavascript and its prerequisites:
 
 ```sh
-ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 brew install pkg-config node zeromq
 sudo easy_install pip
 pip install --upgrade pyzmq jupyter


### PR DESCRIPTION
The readme is incorrect and needs this bash command rather than the ruby command:

```property
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
```